### PR TITLE
Phase 10: Global visual foundation — shadows, chevrons, depth

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -41,6 +41,8 @@ body {
 }
 
 .icon--chevron {
+  width: 16px;
+  height: 16px;
   color: var(--text-tertiary);
   transition: transform 0.2s ease;
 }
@@ -214,7 +216,7 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   min-height: 32px;
-  box-shadow: inset 0 1px 2px rgba(0,0,0,0.06);
+  box-shadow: var(--shadow-inset-sm);
 }
 
 /* === Input with inline prefix icon === */

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -14,6 +14,7 @@
   --accent-subtle: oklch(78% 0.075 196);
   --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.1);
   --shadow-md: 0 2px 8px rgb(0 0 0 / 0.14);
+  --shadow-inset-sm: inset 0 1px 2px rgb(0 0 0 / 0.06);
   --danger: #c2553a;
   --success: #4a8c6f;
 

--- a/src/index.html
+++ b/src/index.html
@@ -16,7 +16,7 @@
           aria-controls="bd-configuration"
         >
           <span class="card-title">Configuration</span>
-          <svg class="icon icon--chevron" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
+          <svg class="icon icon--chevron" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
         </button>
         <div class="card-body" id="bd-configuration">
           <!-- populated by card-configuration.js -->
@@ -31,7 +31,7 @@
           aria-controls="bd-tasks"
         >
           <span class="card-title">Task</span>
-          <svg class="icon icon--chevron" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
+          <svg class="icon icon--chevron" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
         </button>
         <div class="card-body" id="bd-tasks">
           <!-- populated by card-tasks.js -->
@@ -46,7 +46,7 @@
           aria-controls="bd-steps"
         >
           <span class="card-title">Steps</span>
-          <svg class="icon icon--chevron" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
+          <svg class="icon icon--chevron" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
         </button>
         <div class="card-body" id="bd-steps">
           <!-- populated by card-steps.js -->
@@ -61,7 +61,7 @@
           aria-controls="bd-prompt"
         >
           <span class="card-title">Prompt</span>
-          <svg class="icon icon--chevron" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
+          <svg class="icon icon--chevron" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 9.439l3.72-3.719a.749.749 0 0 1 1.06 0Z"/></svg>
         </button>
         <div class="card-body" id="bd-prompt">
           <!-- populated by card-prompt.js -->


### PR DESCRIPTION
- variables.css: add --shadow-sm and --shadow-md; deepen --accent-subtle
  from #aed1d4 to oklch(78% 0.075 196) for stronger selected-state contrast
- styles.css: add base .icon / .icon--sm / .icon--chevron classes;
  remove diamond border-trick .card-chevron; add box-shadow to .card;
  add inset shadow to .input-field for recessed depth
- index.html: replace <span class="card-chevron"> with proper octicon
  chevron-down SVG (.icon .icon--chevron) in all 4 card headers

https://claude.ai/code/session_01XiqP5Ec7q7qVswBrqvC3qS